### PR TITLE
fix: Update version assignment logic for Docker image tagging

### DIFF
--- a/.github/workflows/publish_wpstandalone_image.yml
+++ b/.github/workflows/publish_wpstandalone_image.yml
@@ -35,7 +35,7 @@ jobs:
         # This strips the "v" prefix from the tag name.
         [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
         # This uses the Docker `latest` tag convention.
-        [ "$VERSION" == "main" ] && VERSION=latest
+        [ "$VERSION" == "main" ] && VERSION=latest || VERSION=test
         echo IMAGE_ID=$IMAGE_ID
         echo VERSION=$VERSION
         docker tag $IMAGE_NAME $IMAGE_ID:$VERSION


### PR DESCRIPTION
fix: Update version assignment logic for Docker image tagging